### PR TITLE
Feat: Fix Filter, Frame Panel Bottom & Resolve Screen Stuttering & Fix AR Camera Screen Ratio 4:3

### DIFF
--- a/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
+++ b/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
@@ -2311,14 +2311,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2602,7 +2602,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1129088413}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e42d0e40c3c93724cad9f440b3890122, type: 3}
   m_Name: 
@@ -2651,7 +2651,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1129088413}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f1abc81979a4fc14a889991cd984590d, type: 3}
   m_Name: 
@@ -4110,9 +4110,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e42d0e40c3c93724cad9f440b3890122, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  arFaceManager: {fileID: 0}
-  filterPanel: {fileID: 0}
-  bottomButtons: {fileID: 0}
+  arFaceManager: {fileID: 1784050613}
+  filterPanel: {fileID: 316549603}
+  bottomButtons: {fileID: 1101717110}
 --- !u!1 &1807358805
 GameObject:
   m_ObjectHideFlags: 0

--- a/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
+++ b/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
@@ -1066,7 +1066,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 483.7281}
+  m_AnchoredPosition: {x: 0, y: 257}
   m_SizeDelta: {x: 0.8331299, y: 511.45605}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &316549605
@@ -2074,7 +2074,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 483.72992}
+  m_AnchoredPosition: {x: 0, y: 257.00183}
   m_SizeDelta: {x: 0.8331299, y: 511.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &759799805
@@ -2295,7 +2295,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -1.6739502}
+  m_AnchoredPosition: {x: 0, y: -1.6738281}
   m_SizeDelta: {x: 72, y: -718}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &845585729
@@ -2373,9 +2373,9 @@ RectTransform:
   m_Father: {fileID: 54998138}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 99.77966}
-  m_SizeDelta: {x: 0.8331299, y: 200}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -959.2202}
+  m_SizeDelta: {x: 0.8331299, y: -1918}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1101717112
 MonoBehaviour:
@@ -2390,14 +2390,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2609,6 +2609,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   arFaceManager: {fileID: 1784050613}
   filterPanel: {fileID: 316549603}
+  bottomButtons: {fileID: 1101717110}
 --- !u!224 &1129088415
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2642,6 +2643,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   frameObj: {fileID: 1905444270}
   framePanel: {fileID: 759799803}
+  bottomButtons: {fileID: 1101717110}
 --- !u!114 &1129088417
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2649,7 +2651,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1129088413}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f1abc81979a4fc14a889991cd984590d, type: 3}
   m_Name: 
@@ -2741,6 +2743,7 @@ MonoBehaviour:
   hiddenMissionPanel: {fileID: 2020008360}
   cancelButton: {fileID: 72071914}
   cameraButton: {fileID: 350101263}
+  bottomButtons: {fileID: 1101717110}
   arFaceManager: {fileID: 1784050613}
   saveLoadPicture: {fileID: 1940435777}
 --- !u!1 &1151011470
@@ -3287,6 +3290,7 @@ GameObject:
   - component: {fileID: 1286405052}
   - component: {fileID: 1286405054}
   - component: {fileID: 1286405053}
+  - component: {fileID: 1286405055}
   m_Layer: 5
   m_Name: RawImage_AR
   m_TagString: Untagged
@@ -3348,6 +3352,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1286405051}
   m_CullTransparentMesh: 1
+--- !u!114 &1286405055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1286405051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 1
+  m_AspectRatio: 0.75
 --- !u!1 &1318655094
 GameObject:
   m_ObjectHideFlags: 0
@@ -4094,6 +4112,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   arFaceManager: {fileID: 0}
   filterPanel: {fileID: 0}
+  bottomButtons: {fileID: 0}
 --- !u!1 &1807358805
 GameObject:
   m_ObjectHideFlags: 0

--- a/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
+++ b/HeyCheese/Assets/01.Scenes/CheeseOneCut.unity
@@ -192,8 +192,8 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
+  m_Camera: {fileID: 758211530}
+  m_PlaneDistance: 0.3
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
   m_OverrideSorting: 0
@@ -224,6 +224,7 @@ RectTransform:
   - {fileID: 759799804}
   - {fileID: 2020008361}
   - {fileID: 1477098646}
+  - {fileID: 264006857}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -760,6 +761,57 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 165951791}
   m_CullTransparentMesh: 1
+--- !u!1 &264006856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 264006857}
+  - component: {fileID: 264006858}
+  m_Layer: 5
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &264006857
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264006856}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 54998138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &264006858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 264006856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e42d0e40c3c93724cad9f440b3890122, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  arFaceManager: {fileID: 1784050613}
+  filterPanel: {fileID: 316549603}
+  bottomButtons: {fileID: 759799803}
 --- !u!1 &264838755
 GameObject:
   m_ObjectHideFlags: 0
@@ -3312,10 +3364,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 845585728}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000018464001, y: 0}
+  m_SizeDelta: {x: 1076, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1286405053
 MonoBehaviour:
@@ -4009,7 +4061,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -70.645}
+  m_AnchoredPosition: {x: 0, y: -70.64502}
   m_SizeDelta: {x: -2160, y: 140}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1477098647
@@ -4105,7 +4157,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1784050612}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e42d0e40c3c93724cad9f440b3890122, type: 3}
   m_Name: 
@@ -4895,9 +4947,9 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1251812622}
-  - {fileID: 1784050615}
   - {fileID: 122425591}
   - {fileID: 54998138}
+  - {fileID: 1784050615}
   - {fileID: 705162099}
   - {fileID: 1129088415}
   - {fileID: 1940435778}

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
@@ -11,8 +11,8 @@ public class ARCameraToRawImage : MonoBehaviour
 
     private ARCameraManager cameraManager;
     private Texture2D cameraTexture;
+    private Texture2D rotatedTexture;
     private NativeArray<byte> rawPixelBuffer;
-    private int bufferSize;
 
     void Awake()
     {
@@ -32,41 +32,13 @@ public class ARCameraToRawImage : MonoBehaviour
 
         if (rawPixelBuffer.IsCreated)
             rawPixelBuffer.Dispose();
+
+        if (cameraTexture != null)
+            Destroy(cameraTexture);
+
+        if (rotatedTexture != null)
+            Destroy(rotatedTexture);
     }
-
-    private Texture2D Rotate90(Texture2D originalTexture)
-    {
-        int width = originalTexture.width;
-        int height = originalTexture.height;
-
-        // 회전된 텍스처의 크기는 원본 텍스처의 너비와 높이를 바꾼 값
-        Texture2D rotatedTexture = new Texture2D(height, width, originalTexture.format, false);
-
-        // 원본 텍스처의 색상 데이터를 가져온다.
-        Color32[] originalPixels = originalTexture.GetPixels32();
-
-        // 회전된 텍스처의 색상 배열을 준비합니다
-        Color32[] rotatedPixels = new Color32[originalPixels.Length];
-
-        for (int y = 0; y < height; ++y)
-        {
-            for (int x = 0; x < width; ++x)
-            {
-                // (x, y)를 (rotatedX, rotatedY)로 변환하여 색상 데이터를 복사
-                int rotatedX = y;
-                int rotatedY = width - 1 - x;
-
-                rotatedPixels[rotatedY * height + rotatedX] = originalPixels[y * width + x];
-            }
-        }
-
-        // 회전된 색상 데이터를 새로운 텍스처에 적용
-        rotatedTexture.SetPixels32(rotatedPixels);
-        rotatedTexture.Apply();
-
-        return rotatedTexture;
-    }
-
 
     private void OnCameraFrameReceived(ARCameraFrameEventArgs args)
     {
@@ -75,47 +47,67 @@ public class ARCameraToRawImage : MonoBehaviour
 
         using (cpuImage)
         {
+            int width = cpuImage.width;
+            int height = cpuImage.height;
+            int bufferSize = width * height * 4;
+
+            if (!rawPixelBuffer.IsCreated || rawPixelBuffer.Length != bufferSize)
+            {
+                if (rawPixelBuffer.IsCreated)
+                    rawPixelBuffer.Dispose();
+
+                rawPixelBuffer = new NativeArray<byte>(bufferSize, Allocator.Persistent);
+            }
+
+            if (cameraTexture == null || cameraTexture.width != width || cameraTexture.height != height)
+            {
+                if (cameraTexture != null)
+                    Destroy(cameraTexture);
+                if (rotatedTexture != null)
+                    Destroy(rotatedTexture);
+
+                cameraTexture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+                rotatedTexture = new Texture2D(height, width, TextureFormat.RGBA32, false);
+            }
+
             var conversionParams = new XRCpuImage.ConversionParams
             {
-                inputRect = new RectInt(0, 0, cpuImage.width, cpuImage.height),
-                outputDimensions = new Vector2Int(cpuImage.width, cpuImage.height),
+                inputRect = new RectInt(0, 0, width, height),
+                outputDimensions = new Vector2Int(width, height),
                 outputFormat = TextureFormat.RGBA32,
                 transformation = XRCpuImage.Transformation.MirrorY
             };
 
-            int currentBufferSize = cpuImage.width * cpuImage.height * 4;
-
-            if (cameraTexture == null || cameraTexture.width != cpuImage.width || cameraTexture.height != cpuImage.height)
-            {
-                if (cameraTexture != null)
-                    Destroy(cameraTexture);
-
-                cameraTexture = new Texture2D(cpuImage.width, cpuImage.height, TextureFormat.RGBA32, false);
-                bufferSize = currentBufferSize;
-
-                if (rawPixelBuffer.IsCreated)
-                    rawPixelBuffer.Dispose();
-                rawPixelBuffer = new NativeArray<byte>(bufferSize, Allocator.Persistent);
-            }
-
-            if (bufferSize != currentBufferSize)
-            {
-                bufferSize = currentBufferSize;
-                if (rawPixelBuffer.IsCreated)
-                    rawPixelBuffer.Dispose();
-                rawPixelBuffer = new NativeArray<byte>(bufferSize, Allocator.Persistent);
-            }
-
             cpuImage.Convert(conversionParams, rawPixelBuffer);
             cameraTexture.LoadRawTextureData(rawPixelBuffer);
-
             cameraTexture.Apply();
 
-            // 이미지 회전
-            cameraTexture = Rotate90(cameraTexture);
+            Rotate90(cameraTexture, rotatedTexture);
 
-            rawImage.texture = cameraTexture;
+            rawImage.texture = rotatedTexture;
             rawImage.rectTransform.sizeDelta = new Vector2(Screen.width, Screen.height);
         }
+    }
+
+    private void Rotate90(Texture2D source, Texture2D dest)
+    {
+        Color32[] srcPixels = source.GetPixels32();
+        Color32[] destPixels = new Color32[srcPixels.Length];
+
+        int srcWidth = source.width;
+        int srcHeight = source.height;
+
+        for (int y = 0; y < srcHeight; ++y)
+        {
+            for (int x = 0; x < srcWidth; ++x)
+            {
+                int rotatedX = y;
+                int rotatedY = srcWidth - 1 - x;
+                destPixels[rotatedY * srcHeight + rotatedX] = srcPixels[y * srcWidth + x];
+            }
+        }
+
+        dest.SetPixels32(destPixels);
+        dest.Apply();
     }
 }

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
@@ -85,7 +85,10 @@ public class ARCameraToRawImage : MonoBehaviour
             Rotate90(cameraTexture, rotatedTexture);
 
             rawImage.texture = rotatedTexture;
-            rawImage.rectTransform.sizeDelta = new Vector2(Screen.width, Screen.height);
+
+            int rawImageWidth = Screen.width;
+            int rawImageHeight = (int)(Screen.width * 0.75);
+            rawImage.rectTransform.sizeDelta = new Vector2(rawImageWidth, rawImageHeight);
         }
     }
 

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARCameraToRawImage.cs
@@ -3,7 +3,6 @@ using UnityEngine.UI;
 using UnityEngine.XR.ARFoundation;
 using UnityEngine.XR.ARSubsystems;
 using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
 
 [RequireComponent(typeof(ARCameraManager))]
 public class ARCameraToRawImage : MonoBehaviour
@@ -13,7 +12,6 @@ public class ARCameraToRawImage : MonoBehaviour
     private ARCameraManager cameraManager;
     private Texture2D cameraTexture;
     private NativeArray<byte> rawPixelBuffer;
-    private NativeArray<Color32> colorPixelBuffer;
     private int bufferSize;
 
     void Awake()
@@ -34,35 +32,41 @@ public class ARCameraToRawImage : MonoBehaviour
 
         if (rawPixelBuffer.IsCreated)
             rawPixelBuffer.Dispose();
-        if (colorPixelBuffer.IsCreated)
-            colorPixelBuffer.Dispose();
     }
 
     private Texture2D Rotate90(Texture2D originalTexture)
     {
         int width = originalTexture.width;
         int height = originalTexture.height;
+
+        // 회전된 텍스처의 크기는 원본 텍스처의 너비와 높이를 바꾼 값
         Texture2D rotatedTexture = new Texture2D(height, width, originalTexture.format, false);
 
-        NativeArray<Color32> originalPixels = originalTexture.GetRawTextureData<Color32>();
-        NativeArray<Color32> rotatedPixels = rotatedTexture.GetRawTextureData<Color32>();
+        // 원본 텍스처의 색상 데이터를 가져온다.
+        Color32[] originalPixels = originalTexture.GetPixels32();
 
-        int originalStride = width;
-        int rotatedStride = height;
+        // 회전된 텍스처의 색상 배열을 준비합니다
+        Color32[] rotatedPixels = new Color32[originalPixels.Length];
 
         for (int y = 0; y < height; ++y)
         {
             for (int x = 0; x < width; ++x)
             {
-                rotatedPixels[x * rotatedStride + (rotatedStride - 1 - y)] = originalPixels[y * originalStride + x];
+                // (x, y)를 (rotatedX, rotatedY)로 변환하여 색상 데이터를 복사
+                int rotatedX = y;
+                int rotatedY = width - 1 - x;
+
+                rotatedPixels[rotatedY * height + rotatedX] = originalPixels[y * width + x];
             }
         }
 
+        // 회전된 색상 데이터를 새로운 텍스처에 적용
+        rotatedTexture.SetPixels32(rotatedPixels);
         rotatedTexture.Apply();
-        originalPixels.Dispose();
-        rotatedPixels.Dispose();
+
         return rotatedTexture;
     }
+
 
     private void OnCameraFrameReceived(ARCameraFrameEventArgs args)
     {
@@ -88,11 +92,13 @@ public class ARCameraToRawImage : MonoBehaviour
 
                 cameraTexture = new Texture2D(cpuImage.width, cpuImage.height, TextureFormat.RGBA32, false);
                 bufferSize = currentBufferSize;
+
                 if (rawPixelBuffer.IsCreated)
                     rawPixelBuffer.Dispose();
                 rawPixelBuffer = new NativeArray<byte>(bufferSize, Allocator.Persistent);
             }
-            else if (bufferSize != currentBufferSize)
+
+            if (bufferSize != currentBufferSize)
             {
                 bufferSize = currentBufferSize;
                 if (rawPixelBuffer.IsCreated)
@@ -102,6 +108,7 @@ public class ARCameraToRawImage : MonoBehaviour
 
             cpuImage.Convert(conversionParams, rawPixelBuffer);
             cameraTexture.LoadRawTextureData(rawPixelBuffer);
+
             cameraTexture.Apply();
 
             // 이미지 회전
@@ -109,7 +116,6 @@ public class ARCameraToRawImage : MonoBehaviour
 
             rawImage.texture = cameraTexture;
             rawImage.rectTransform.sizeDelta = new Vector2(Screen.width, Screen.height);
-            rawImage.rectTransform.localEulerAngles = new Vector3(0, 0, 180);
         }
     }
 }

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARFaceFilterApplier.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/ARFaceFilterApplier.cs
@@ -12,6 +12,7 @@ public class ARFaceFilterApplier : MonoBehaviour
     private string filterName;
 
     public GameObject filterPanel;
+    public GameObject bottomButtons;
 
     private Dictionary<string, int> faceLandmarkIndices = new Dictionary<string, int>
     {
@@ -56,6 +57,7 @@ public class ARFaceFilterApplier : MonoBehaviour
 
         InstantiateFilterPrefabs();
         filterPanel.SetActive(false);
+        bottomButtons.SetActive(true);
     }
 
     private void InstantiateFilterPrefabs()
@@ -146,5 +148,6 @@ public class ARFaceFilterApplier : MonoBehaviour
         filterName = null;
         SetPrefabVisibility(false);
         filterPanel.SetActive(false);
+        bottomButtons.SetActive(true);
     }
 }

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/CheeseOneCutUIManager.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/CheeseOneCutUIManager.cs
@@ -14,6 +14,8 @@ public class CheeseOneCutUIManager : MonoBehaviour
 
     public Button cancelButton;
     public Button cameraButton;
+    // 하단 버튼
+    public GameObject bottomButtons;
 
     [SerializeField]
     private ARFaceManager arFaceManager;
@@ -34,6 +36,7 @@ public class CheeseOneCutUIManager : MonoBehaviour
     {
         UpdateFrameButtons();
         framePanel.SetActive(true);
+        bottomButtons.SetActive(false);
 
         cancelButton.interactable = true;
     }
@@ -42,6 +45,7 @@ public class CheeseOneCutUIManager : MonoBehaviour
     {
         UpdateFilterButtons();
         filterPanel.SetActive(true);
+        bottomButtons.SetActive(false);
 
         cancelButton.interactable = true;
     }
@@ -57,6 +61,7 @@ public class CheeseOneCutUIManager : MonoBehaviour
             filterPanel.SetActive(false);
         }
 
+        bottomButtons.SetActive(true);
         cancelButton.interactable = false;
     }
 

--- a/HeyCheese/Assets/02.Scripts/CheeseOneCut/FrameApplier.cs
+++ b/HeyCheese/Assets/02.Scripts/CheeseOneCut/FrameApplier.cs
@@ -9,6 +9,7 @@ public class FrameApplier : MonoBehaviour
     private GameObject frameObj;
     private Image frameImg;
     public GameObject framePanel;
+    public GameObject bottomButtons;
 
     private string frameName;
 
@@ -48,11 +49,13 @@ public class FrameApplier : MonoBehaviour
         }
 
         framePanel.SetActive(false);
+        bottomButtons.SetActive(true);
     }
 
     public void RemoveFrame()
     {
         frameObj.SetActive(false);
         framePanel.SetActive(false);
+        bottomButtons.SetActive(true);
     }
 }


### PR DESCRIPTION
- 필터, 프레임 패널을 맨 밑에 띄움
- 필터, 프레임 패널이 뜨면 하단 버튼(갤러리, 카메라, 필터/프레임 패널 열기 버튼)이 안 보이게 비활성화
- 필터, 프레임 패널이 닫힐 때 하단 버튼들이 다시 활성화 되도록 함

- 최적화를 통해 화면이 버벅거리다가 튕기는 문제 해결 완료
- AR 카메라 화면 비율 4:3으로 고정